### PR TITLE
chore(cli): do not look up target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Toolchain
@@ -24,7 +21,6 @@ jobs:
           rustup component add rust-src --toolchain 1.90.0
           rustup update stable && rustup default stable
       - uses: taiki-e/install-action@sccache
-      - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@nextest
       - name: Run Tests
         run: cargo nextest run --no-fail-fast --release
@@ -48,3 +44,23 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --all -- -D warnings
+
+  template:
+    name: Template
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Toolchain
+        run: rustup update stable && rustup default stable
+      - uses: taiki-e/install-action@sccache
+      - name: Test template service
+        run: |
+          cargo install --path crates/jade
+          jade new my-service
+          cd my-service
+          cargo build
+          cargo test
+          ls target/jam

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: taiki-e/install-action@sccache
       - name: Test template service
         run: |
-          cargo install --path crates/jade
+          cargo install --path crates/jade && cd
           jade new my-service
           cd my-service
           cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cjam"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -391,7 +391,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jade"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "anyhow",
  "cjam",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "jade-derive"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "polkavm-derive-impl",
  "proc-macro2",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "jade-testing"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "anyhow",
  "cjam",
@@ -522,7 +522,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nauth"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "cjam",
  "jade",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "serde-jam"
-version = "0.0.13"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898d2c5713cad74d319eae03319eaaf024b53683be8db823f91ac81e35385897"
+checksum = "cb71b2f9b7d3565f429afe8ab1741dd795c9e0b7b1bd8d69d5a20091592bd2d3"
 dependencies = [
  "anyhow",
  "serde",
@@ -850,9 +850,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spacejam-service"
-version = "0.0.13"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4537ded3f33d4bd089dfb76a54ad1f824d9324ff7da5310775e6bad7046b88ee"
+checksum = "24556f78f817dd125ce274bc43fd3b02d3a806921b06d95474e413947198e96f"
 dependencies = [
  "anyhow",
  "blake2",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "spacejson"
-version = "0.0.13"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428fd09eab6995f5598ae62a9176599a189ccbd76c64d59ff936563efe936c2e"
+checksum = "6750510bd2dd32baab2e2bb393702c1b08b1eeb3aa5c36d37ba330f4143d4c2f"
 dependencies = [
  "anyhow",
  "hex",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "spacejson-derive"
-version = "0.0.13"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b335da6a78a99eb68bb3b1df2568b6a24b4addc132fd048406e9f6299a68b21d"
+checksum = "796b5d679e927d0e18f5c005350ae5692832be9d54c1f4d6fe79e178016dfc18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "spacevm-sys"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "anyhow",
  "serde-jam",
@@ -903,7 +903,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stoken"
-version = "0.0.13"
+version = "0.0.15-pre.1"
 dependencies = [
  "cjam",
  "jade",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/jade/derive", "services/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.13"
+version = "0.0.15-pre.1"
 edition = "2024"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
 license = "GPL-3.0"
@@ -11,19 +11,19 @@ homepage = "https://spacejam.app"
 repository = "https://github.com/spacejamapp/jade"
 
 [workspace.dependencies]
-cjam = { path = "crates/cli", version = "0.0.13" }
-jade = { path = "crates/jade", default-features = false, version = "0.0.13" }
-jade-derive = { path = "crates/jade/derive", version = "0.0.13" }
-spacevm = { path = "crates/sys", package = "spacevm-sys", version = "0.0.13" }
-testing = { path = "crates/testing", package = "jade-testing", version = "0.0.13" }
+cjam = { path = "crates/cli", version = "0.0.15-pre.1" }
+jade = { path = "crates/jade", default-features = false, version = "0.0.15-pre.1" }
+jade-derive = { path = "crates/jade/derive", version = "0.0.15-pre.1" }
+spacevm = { path = "crates/sys", package = "spacevm-sys", version = "0.0.15-pre.1" }
+testing = { path = "crates/testing", package = "jade-testing", version = "0.0.15-pre.1" }
 
 # services
 nauth = { path = "services/nauth" }
 stoken = { path = "services/stoken" }
 
 # spacejam dependencies
-codec = { package = "serde-jam", version = "0.0.13", default-features = false }
-service = { package = "spacejam-service", version = "0.0.13", default-features = false }
+codec = { package = "serde-jam", version = "0.0.14", default-features = false }
+service = { package = "spacejam-service", version = "0.0.14", default-features = false }
 
 # crates.io
 anyhow = { version = "1.0.93", default-features = false }

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ cargo build
 cargo test
 ```
 
-See also our template at [service-template](https://github.com/spacejamapp/service-template).
+- See [the scripts in the CI][CI_TPL] for a working example
+- For the template service generated via `jade new`, check [service-template][template]
 
 ## License
 
 GPL-3.0
+
+[CI_TPL]: https://github.com/spacejamapp/service-template/blob/main/.github/workflows/main.yml#L62-L66
+[template]: https://github.com/spacejamapp/service-template

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Jade framework for building JAM services by [SpaceJam](https://spacejam.app).
 ## Quick Start
 
 ```
-cargo install jade
+cargo install jade --git https://github.com/spacejamapp/jade
 jade new my-service
 cd my-service
-jade build
+cargo build
+cargo test
 ```
 
 See also our template at [service-template](https://github.com/spacejamapp/service-template).

--- a/crates/cli/src/builder.rs
+++ b/crates/cli/src/builder.rs
@@ -89,7 +89,6 @@ pub fn build_pvm_blob(
     crate_dir: &Path,
     blob_type: BlobType,
     out_dir: &Path,
-    install_rustc: bool,
     profile: ProfileType,
 ) -> (String, PathBuf) {
     let (target_name, target_json_path) = (
@@ -117,28 +116,24 @@ pub fn build_pvm_blob(
                 .split(|x| *x == b'\n')
                 .any(|x| x[..] == b"rust-src"[..])
         {
-            if install_rustc {
-                println!("Installing rustc dependencies...");
-                let mut child = Command::new("rustup")
-                    .args(["toolchain", "install", TOOLCHAIN, "-c", "rust-src"])
-                    .stdout(std::process::Stdio::inherit())
-                    .stderr(std::process::Stdio::inherit())
-                    .spawn()
-                    .unwrap_or_else(|_| {
-                        panic!(
-						"Failed to execute `rustup toolchain install {TOOLCHAIN} -c rust-src`.\n\
+            println!("Installing rustc dependencies...");
+            let mut child = Command::new("rustup")
+                .args(["toolchain", "install", TOOLCHAIN, "-c", "rust-src"])
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .spawn()
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Failed to execute `rustup toolchain install {TOOLCHAIN} -c rust-src`.\n\
 				Please install `rustup` to continue."
-					)
-                    });
-                if !child
-                    .wait()
-                    .expect("Failed to execute rustup process")
-                    .success()
-                {
-                    panic!("Failed to install `rust-src` component of {TOOLCHAIN}.");
-                }
-            } else {
-                panic!("`rust-src` component of {TOOLCHAIN} is required to build the PVM binary.",);
+                    )
+                });
+            if !child
+                .wait()
+                .expect("Failed to execute rustup process")
+                .success()
+            {
+                panic!("Failed to install `rust-src` component of {TOOLCHAIN}.");
             }
         }
         println!("ℹ️ `rustup` and toolchain installed. Continuing build process...");

--- a/crates/cli/src/cmd/build.rs
+++ b/crates/cli/src/cmd/build.rs
@@ -19,9 +19,6 @@ pub struct Build {
     /// Module type to build.
     #[arg(short, long, value_enum, default_value_t = ModuleType::Automatic)]
     pub module: ModuleType,
-    /// Install rustc dependencies if missing.
-    #[arg(long)]
-    auto_install: bool,
     /// The build profile to use.
     #[arg(long, value_enum, default_value_t = Profile::Release)]
     profile: Profile,
@@ -74,7 +71,6 @@ impl Build {
             &crate_dir,
             blob_type,
             out_dir.as_path(),
-            self.auto_install,
             self.profile.clone().into(),
         );
 

--- a/crates/jade/derive/src/accumulate.rs
+++ b/crates/jade/derive/src/accumulate.rs
@@ -22,8 +22,8 @@ pub fn accumulate(_args: TokenStream, input: TokenStream) -> TokenStream {
             let buf = unsafe { core::slice::from_raw_parts(ptr as *const u8, size as usize) };
             let jade::service::vm::AccumulateParams {slot, id, results} =
                 jade::codec::decode(buf).expect("failed to decode accumulate parameters");
-            let operands = jade::host::fetch::operands().expect("failed to fetch operands");
-            if let Some(result) = #funame(slot, id, operands) {
+            let items = jade::host::fetch::items().expect("failed to fetch accumulate items");
+            if let Some(result) = #funame(slot, id, items) {
                 ((&result).as_ptr() as u64, result.len() as u64)
             } else {
                 (0, 0)

--- a/crates/jade/src/host/general.rs
+++ b/crates/jade/src/host/general.rs
@@ -13,10 +13,10 @@ pub mod fetch {
     use super::*;
     use crate::prelude::{Vec, vec};
     use anyhow::Result;
-    use service::vm::Operand;
+    use service::vm::AccumulateItem;
 
     /// Fetch a value from the storage
-    pub fn operands() -> Result<Vec<Operand>> {
+    pub fn items() -> Result<Vec<AccumulateItem>> {
         let len = unsafe { import::fetch(core::ptr::null_mut(), 0, 0, 14, 0, 0) };
         let mut target = vec![0; len as usize];
         let _ = unsafe { import::fetch(target.as_mut_ptr(), 0, len as u64, 14, 0, 0) };

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -8,8 +8,8 @@ use std::{
     process::{Command, Stdio},
 };
 
-const LIB_BASE: &str = "https://github.com/spacejamapp/specjam/releases/download/0.7.0-pre.9";
-const LIB_NAME: &str = "spacevm-0.7.0";
+const LIB_BASE: &str = "https://github.com/spacejamapp/specjam/releases/download/0.7.1-pre.1";
+const LIB_NAME: &str = "spacevm-0.7.1";
 const PLATFORMS: [&str; 4] = ["linux-amd64", "linux-arm64", "macos-amd64", "macos-arm64"];
 
 fn main() -> std::io::Result<()> {

--- a/crates/testing/src/exec.rs
+++ b/crates/testing/src/exec.rs
@@ -9,7 +9,7 @@ use service::{
         ValidatorData,
     },
     service::{
-        Privileges, RefineLoad, ServiceAccount, WorkExecResult, WorkPackage, WorkResult,
+        Privileges, RefineLoad, ServiceAccount, WorkDigest, WorkExecResult, WorkPackage,
         result::Executed,
     },
     vm::Operand,
@@ -88,7 +88,7 @@ impl Jam {
     ///
     /// NOTE: run refine for all work items
     #[tracing::instrument(name = "refine", skip_all)]
-    pub fn refine(&mut self, work: &WorkPackage) -> Result<Vec<WorkResult>> {
+    pub fn refine(&mut self, work: &WorkPackage) -> Result<Vec<WorkDigest>> {
         tracing::debug!("package: items={}", work.items.len());
         if work.items.is_empty() {
             anyhow::bail!("no work items");
@@ -114,7 +114,7 @@ impl Jam {
                 ));
             }
 
-            result.push(WorkResult {
+            result.push(WorkDigest {
                 service_id: item.service,
                 code_hash: item.code_hash,
                 payload_hash: Default::default(),
@@ -139,7 +139,7 @@ impl Jam {
     /// 2. run accumulate for all work items
     /// 3. return the accumulated result
     #[tracing::instrument(name = "accumulate", skip_all)]
-    pub fn accumulate(&mut self, results: Vec<WorkResult>) -> Result<Vec<Accumulated>> {
+    pub fn accumulate(&mut self, results: Vec<WorkDigest>) -> Result<Vec<Accumulated>> {
         tracing::debug!("work: items={}", results.len());
         if results.is_empty() {
             anyhow::bail!("no results");

--- a/services/stoken/src/service.rs
+++ b/services/stoken/src/service.rs
@@ -4,7 +4,11 @@ use crate::{Holders, Instruction};
 use jade::{
     error, info,
     prelude::Vec,
-    service::{OpaqueHash, service::WorkExecResult, vm::Operand},
+    service::{
+        OpaqueHash,
+        service::WorkExecResult,
+        vm::{AccumulateItem, Operand},
+    },
 };
 
 #[jade::refine]
@@ -32,11 +36,15 @@ fn refine(
 }
 
 #[jade::accumulate]
-fn accumulate(_now: u32, _id: u32, results: Vec<Operand>) -> Option<OpaqueHash> {
-    info!("accumulate items: {}", results.len());
+fn accumulate(_now: u32, _id: u32, items: Vec<AccumulateItem>) -> Option<OpaqueHash> {
+    info!("accumulate items: {}", items.len());
     let mut holders = Holders::get();
-    for raw_instructions in results.into_iter().filter_map(|x| {
-        if let WorkExecResult::Ok(data) = x.data {
+    for raw_instructions in items.into_iter().filter_map(|x| {
+        if let AccumulateItem::Operand(Operand {
+            data: WorkExecResult::Ok(data),
+            ..
+        }) = x
+        {
             Some(data)
         } else {
             None


### PR DESCRIPTION
Resolves #17 

The problem is that the `target` folder does not exist before we can `cargo build` or `cargo test` that we got look up failed on `jade build`, now we switch to looking up `Cargo.toml` for the workspace root